### PR TITLE
Fixed the Class Name BlogAppConfig

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -37,7 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'blog_app.apps.BlogappConfig'
+    'blog_app.apps.BlogAppConfig'
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
the class name in blog_app had a typo and its now fixed. the previous name was 'BlogappConfig' and I modified it to 'BlogAppConfig'